### PR TITLE
Provides a data-api to create popovers on click.

### DIFF
--- a/jquery.cf.popover.js
+++ b/jquery.cf.popover.js
@@ -214,4 +214,19 @@
 	
 	/* Expose constructor function for folks to duck-type when necessary */
 	fn.popover.Popover = Popover;
+
+	$(function() {
+		$('body').on('click.cf.popover.data-api', '[data-toggle="popover"]', function ( e ) {
+			var $this = $(this)
+			  , href = $this.attr('href')
+			  , $target = $($this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, ''))) //strip for ie7
+			  , options = $this.data();
+
+			e.preventDefault();
+
+			data = $this.data('popover');
+			if (!data) $this.popover(options).data('popover').show();
+		});
+	});
+
 })(jQuery);


### PR DESCRIPTION
Hey guys,

We've been using this plugin for quite awhile in production. We're refactoring some things and wanted a data-api for this library. Rather than tear this out and use a different popover plugin, it was pretty simple to add a data-api.

This follows the Bootstrap pattern for a data-api which they use on most of their javascript components.

Example usage:

``` html
<a href="#popover" data-toggle="popover">Trigger popover</a>
```
